### PR TITLE
Fixing Warnings

### DIFF
--- a/src/BarPanel/barPanel.js
+++ b/src/BarPanel/barPanel.js
@@ -13,7 +13,7 @@ class BarPanel extends Component {
     buttonsConfiguration: PropTypes.array.isRequired,
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     Dimensions.addEventListener('change', () => {
       this.forceUpdate();
     });

--- a/src/TabButton/index.js
+++ b/src/TabButton/index.js
@@ -6,7 +6,7 @@ import TabButton from './tabButton';
 class TabButtonContainer extends Component {
   static propTypes = {
     onPress: PropTypes.func.isRequired,
-    viewWidth: PropTypes.oneOfType([PropTypes.number, undefined]),
+    viewWidth: PropTypes.number,
     buttonConfiguration: PropTypes.object.isRequired,
   }
 

--- a/src/TabButton/tabButton.js
+++ b/src/TabButton/tabButton.js
@@ -34,7 +34,7 @@ const viewScaleInterpolationConfig = {
 class TabButton extends Component {
   static propTypes = {
     onPress: PropTypes.func.isRequired,
-    viewWidth: PropTypes.oneOfType([PropTypes.number, undefined]),
+    viewWidth: PropTypes.number,
     buttonConfiguration: PropTypes.object.isRequired,
   }
 


### PR DESCRIPTION
This fixes the warning:
> Warning: Invalid argument supplied to oneOfType. Expected an array of check functions, but received undefined at index 1.
> - node_modules/expo/build/environment/muteWarnings.fx.js:27:24 in error
> - node_modules/prop-types/factoryWithTypeCheckers.js:23:20 in printWarning
> - node_modules/prop-types/factoryWithTypeCheckers.js:373:10 in createUnionTypeChecker
> - node_modules/@opengeekslab/react-native-tab-navigator/src/TabButton/index.js:8:28 in TabButtonContainer
> - node_modules/metro/src/lib/polyfills/require.js:322:6 in loadModuleImplementation

And:

> Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.
> 
> * Move code with side effects to componentDidMount, and set initial state in the constructor.
> * Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
> 
> Please update the following components: BarPanel